### PR TITLE
TXT形式エクスポート機能とファイル自動オープン機能を追加

### DIFF
--- a/src/FinderScope.Core/Services/IExportService.cs
+++ b/src/FinderScope.Core/Services/IExportService.cs
@@ -22,6 +22,11 @@ namespace FinderScope.Core.Services
         /// HTML形式でエクスポート
         /// </summary>
         Task ExportToHtmlAsync(SearchResult searchResult, string filePath);
+
+        /// <summary>
+        /// TXT形式でエクスポート
+        /// </summary>
+        Task ExportToTxtAsync(SearchResult searchResult, string filePath);
     }
 
     /// <summary>
@@ -31,6 +36,7 @@ namespace FinderScope.Core.Services
     {
         Csv,
         Json,
-        Html
+        Html,
+        Txt
     }
 }

--- a/src/FinderScope.WPF/ViewModels/MainWindowViewModel.cs
+++ b/src/FinderScope.WPF/ViewModels/MainWindowViewModel.cs
@@ -250,6 +250,12 @@ namespace FinderScope.WPF.ViewModels
             await ExportResultsAsync(ExportFormat.Html, "HTML ファイル (*.html)|*.html");
         }
 
+        [RelayCommand]
+        private async Task ExportToTxtAsync()
+        {
+            await ExportResultsAsync(ExportFormat.Txt, "テキスト ファイル (*.txt)|*.txt");
+        }
+
         private async Task ExportResultsAsync(ExportFormat format, string filter)
         {
             if (_lastSearchResult == null || !_lastSearchResult.FileMatches.Any())
@@ -280,14 +286,46 @@ namespace FinderScope.WPF.ViewModels
                         case ExportFormat.Html:
                             await _exportService.ExportToHtmlAsync(_lastSearchResult, saveDialog.FileName);
                             break;
+                        case ExportFormat.Txt:
+                            await _exportService.ExportToTxtAsync(_lastSearchResult, saveDialog.FileName);
+                            break;
                     }
 
-                    WinMessageBox.Show($"エクスポートが完了しました。\n{saveDialog.FileName}", "完了", MessageBoxButton.OK, MessageBoxImage.Information);
+                    // エクスポート完了ダイアログを表示し、ファイルを開くかどうか確認
+                    var result = WinMessageBox.Show(
+                        $"エクスポートが完了しました。\n{saveDialog.FileName}\n\nファイルを開きますか？", 
+                        "エクスポート完了", 
+                        MessageBoxButton.YesNo, 
+                        MessageBoxImage.Information);
+
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        OpenExportedFile(saveDialog.FileName);
+                    }
                 }
                 catch (Exception ex)
                 {
                     WinMessageBox.Show($"エクスポート中にエラーが発生しました: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
+            }
+        }
+
+        /// <summary>
+        /// エクスポートされたファイルを開く
+        /// </summary>
+        private void OpenExportedFile(string filePath)
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = filePath,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                WinMessageBox.Show($"ファイルを開けませんでした: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 

--- a/src/FinderScope.WPF/Views/MainWindow.xaml
+++ b/src/FinderScope.WPF/Views/MainWindow.xaml
@@ -77,7 +77,8 @@
                     <!-- エクスポートボタン -->
                     <Button Content="CSV出力" Command="{Binding ExportToCsvCommand}" Width="80" Height="30" Margin="0,0,5,0"/>
                     <Button Content="JSON出力" Command="{Binding ExportToJsonCommand}" Width="80" Height="30" Margin="0,0,5,0"/>
-                    <Button Content="HTML出力" Command="{Binding ExportToHtmlCommand}" Width="80" Height="30"/>
+                    <Button Content="HTML出力" Command="{Binding ExportToHtmlCommand}" Width="80" Height="30" Margin="0,0,5,0"/>
+                    <Button Content="TXT出力" Command="{Binding ExportToTxtCommand}" Width="80" Height="30"/>
                 </StackPanel>
             </Grid>
         </GroupBox>

--- a/tests/FinderScope.Tests/Services/ExportServiceTests.cs
+++ b/tests/FinderScope.Tests/Services/ExportServiceTests.cs
@@ -187,6 +187,51 @@ namespace FinderScope.Tests.Services
         }
 
         [Test]
+        public async Task ExportToTxtAsync_CreatesValidTxtFile()
+        {
+            // Arrange
+            var txtPath = Path.Combine(_tempDirectory, "test.txt");
+
+            // Act
+            await _exportService.ExportToTxtAsync(_testSearchResult, txtPath);
+
+            // Assert
+            File.Exists(txtPath).Should().BeTrue();
+            
+            var txtContent = await File.ReadAllTextAsync(txtPath);
+            txtContent.Should().NotBeNullOrWhiteSpace();
+            txtContent.Should().Contain("=== Finder Scope 検索結果 ===");
+            txtContent.Should().Contain("test1.txt");
+            txtContent.Should().Contain("test2.log");
+            txtContent.Should().Contain("検索結果統計");
+            txtContent.Should().Contain("検索結果一覧");
+        }
+
+        [Test]
+        public async Task ExportToTxtAsync_WithEmptyResults_CreatesValidFile()
+        {
+            // Arrange
+            var emptyResult = new SearchResult
+            {
+                Criteria = new SearchCriteria { TargetFolder = @"C:\Empty" },
+                SearchStartTime = DateTime.Now,
+                SearchDurationSeconds = 0.1,
+                TotalFilesScanned = 0
+            };
+            var txtPath = Path.Combine(_tempDirectory, "empty.txt");
+
+            // Act
+            await _exportService.ExportToTxtAsync(emptyResult, txtPath);
+
+            // Assert
+            File.Exists(txtPath).Should().BeTrue();
+            
+            var txtContent = await File.ReadAllTextAsync(txtPath);
+            txtContent.Should().Contain("=== Finder Scope 検索結果 ===");
+            txtContent.Should().Contain("マッチするファイルが見つかりませんでした。");
+        }
+
+        [Test]
         public void ExportToCsvAsync_WithInvalidPath_ThrowsException()
         {
             // Arrange


### PR DESCRIPTION
- IExportService に ExportToTxtAsync メソッドを追加
- ExportService にTXT形式エクスポート実装を追加
- 構造化されたテキスト形式で検索結果をエクスポート
- エクスポート後にファイルを開くかどうかの確認ダイアログを追加
- エクスポート完了後のファイル自動オープン機能を実装
- MainWindow.xaml にTXT出力ボタンを追加
- TXT形式エクスポートの包括的なテストを追加

fixes #3